### PR TITLE
Add Azelezasl to contributors section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,10 +144,14 @@ Follow these instructions to get a copy of the project up and running on your lo
       <br/>
       <a href="https://github.com/Milkdrinker-creator">Milkdrinker-creator</a>
     </td>
+        <td align="center" style="border: 1px solid #555; padding: 10px;">
+      <a href="https://github.com/Azelezasl">
+        <img src="https://github.com/Azelezasl.png" width="100" height="100" alt="Azelezasl" style="border-radius: 50%;"/>
+      </a>
+      <br/>
+      <a href="https://github.com/Azelezasl">Azelezasl</a>
+    </td>
     
   </tr>
 </table>
 
-
----
-Made with ❤️ for a school assignment.


### PR DESCRIPTION
Updated the contributors table in README.md to include Azelezasl with profile image and link. Removed redundant footer text for clarity.